### PR TITLE
Add `NotificationDriver` class

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/edu/wisc/ece/pinpoint/MainActivity.java
+++ b/app/src/main/java/edu/wisc/ece/pinpoint/MainActivity.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import edu.wisc.ece.pinpoint.utils.FirebaseDriver;
 import edu.wisc.ece.pinpoint.utils.LocationDriver;
+import edu.wisc.ece.pinpoint.utils.NotificationDriver;
 
 public class MainActivity extends AppCompatActivity {
     private static final List<Integer> hiddenNavbarFragments =
@@ -33,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
         BottomNavigationView navBar = findViewById(R.id.navBar);
         BottomAppBar navBarContainer = findViewById(R.id.bottomBar);
         FloatingActionButton mapButton = findViewById(R.id.mapButton);
+        NotificationDriver.getInstance(this);
         navBar.getMenu().getItem(2).setEnabled(false);
         NavigationUI.setupWithNavController(navBar, navController);
 

--- a/app/src/main/java/edu/wisc/ece/pinpoint/pages/newpin/NewPinFragment.java
+++ b/app/src/main/java/edu/wisc/ece/pinpoint/pages/newpin/NewPinFragment.java
@@ -27,6 +27,7 @@ import edu.wisc.ece.pinpoint.data.Pin;
 import edu.wisc.ece.pinpoint.data.Pin.PinType;
 import edu.wisc.ece.pinpoint.utils.FirebaseDriver;
 import edu.wisc.ece.pinpoint.utils.LocationDriver;
+import edu.wisc.ece.pinpoint.utils.NotificationDriver;
 import edu.wisc.ece.pinpoint.utils.ValidationUtils;
 
 public class NewPinFragment extends Fragment {
@@ -138,6 +139,8 @@ public class NewPinFragment extends Fragment {
                 Log.d(TAG, "DocumentSnapshot written with ID: " + documentReference.getId());
                 Toast.makeText(requireContext(), "Successfully dropped Pin!", Toast.LENGTH_SHORT)
                         .show();
+                NotificationDriver notifDriver = NotificationDriver.getInstance(null);
+                notifDriver.sendOneShot("New Pin Dropped!", "You have successfully dropped a new Pin.");
                 // TODO: navigate user to pin view page
             }).addOnFailureListener(e -> {
                 Log.w(TAG, "Error adding document", e);

--- a/app/src/main/java/edu/wisc/ece/pinpoint/utils/NotificationDriver.java
+++ b/app/src/main/java/edu/wisc/ece/pinpoint/utils/NotificationDriver.java
@@ -1,0 +1,115 @@
+package edu.wisc.ece.pinpoint.utils;
+
+import android.app.Activity;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.app.NotificationCompat;
+import androidx.core.content.ContextCompat;
+
+import edu.wisc.ece.pinpoint.MainActivity;
+import edu.wisc.ece.pinpoint.R;
+
+/**
+ * So this class is kinda jank cause we need one instance of it shared across the entire app.
+ * The way I'm accomplishing this now is to have a static instance of this class within itself, so
+ * we populate the instance once in MainActivity, and then just call NotificationDriver.getInstance(null)
+ * to get the same instance anywhere in the app. Essentially anytime you want to send notifications
+ * in the app, just run e.g.
+ * <pre>
+ *   NotificationDriver
+ *        .getInstance(null)
+ *        .sendOneShot("title", "contents");
+ * </pre>
+ */
+public class NotificationDriver {
+     public static final String POST_NOTIFICATIONS = "android.permission.POST_NOTIFICATIONS";
+     private final Context context;
+     private static NotificationDriver instance;
+     private NotificationManager manager;
+     private final String PERSISTENT_CHANNEL_ID = "pinpointPersistentChannel";
+     private final String ONESHOT_CHANNEL_ID = "pinpointOneshotChannel";
+     private int idCounter;
+     private int persistentID;
+     private String persistentTitle = "Uninitialized title!";
+
+     private NotificationDriver(Context context) {
+          this.context = context;
+          this.manager = (NotificationManager) this.context.getSystemService(Context.NOTIFICATION_SERVICE);
+          this.idCounter = 0;
+          this.persistentID = -1;
+          createNotificationChannel(this.PERSISTENT_CHANNEL_ID, "Persistent Pin Updates");
+          createNotificationChannel(this.ONESHOT_CHANNEL_ID, "Misc PinPoint Notifications");
+     }
+
+     public static NotificationDriver getInstance(Context context) {
+          // if we haven't instantiated a NotificationDriver yet, do so
+          if (instance == null) {
+               instance = new NotificationDriver(context);
+          } else {
+               // otherwise, make sure we have permissions before returning
+               instance.checkPermissions();
+               // TODO: seems like the first notification sent right after accepting permissions doesn't show up
+          }
+          return instance;
+     }
+
+     public void checkPermissions() {
+          // as of android 13, we need to explicitly ask for notification permissions
+          if (ContextCompat.checkSelfPermission(this.context, POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+               ActivityCompat.requestPermissions((Activity) this.context, new String[]{ POST_NOTIFICATIONS }, 0);
+          }
+     }
+
+     public void updatePersistent(String content) {
+          updatePersistent(this.persistentTitle, content);
+     }
+     public void updatePersistent(String title, String content) {
+          // if we haven't made a persistent notification yet, create a new one
+          if (this.persistentID == -1) {
+               this.persistentID = sendNotification(title, content, this.PERSISTENT_CHANNEL_ID);
+          } else {
+               sendNotification(title, content, this.PERSISTENT_CHANNEL_ID, this.persistentID);
+          }
+     }
+
+     public void sendOneShot(String title, String content) {
+          sendNotification(title, content, this.ONESHOT_CHANNEL_ID);
+     }
+
+     private int sendNotification(String title, String content, String channelID) {
+          int ID = this.idCounter++;
+          sendNotification(title, content, channelID, ID);
+          return ID;
+     }
+
+     private void sendNotification(String title, String content, String channelID, int notifID) {
+          Intent notificationIntent = new Intent(this.context, MainActivity.class);
+          PendingIntent notificationPendingIntent = PendingIntent.getActivity(this.context,
+                  0, notificationIntent,
+                  PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+
+          NotificationCompat.Builder builder = new NotificationCompat.Builder(this.context, channelID)
+                  .setSmallIcon(R.drawable.ic_notif_icon_small)
+                  .setContentTitle(title)
+                  .setContentText(content)
+                  .setContentIntent(notificationPendingIntent)
+                  .setAutoCancel(true)
+                  .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                  .setDefaults(NotificationCompat.DEFAULT_ALL);
+
+          this.manager.notify(notifID, builder.build());
+     }
+
+     private void createNotificationChannel(String channelID, String channelName) {
+          int importance = NotificationManager.IMPORTANCE_DEFAULT;
+          NotificationChannel channel = new NotificationChannel(channelID, channelName, importance);
+          this.manager.createNotificationChannel(channel);
+     }
+
+}

--- a/app/src/main/res/drawable/ic_notif_icon_small.xml
+++ b/app/src/main/res/drawable/ic_notif_icon_small.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,8c0,-3.31 -2.69,-6 -6,-6S6,4.69 6,8c0,4.5 6,11 6,11s6,-6.5 6,-11zM10,8c0,-1.1 0.9,-2 2,-2s2,0.9 2,2 -0.89,2 -2,2c-1.1,0 -2,-0.9 -2,-2zM5,20v2h14v-2L5,20z"/>
+</vector>


### PR DESCRIPTION
Initial work for `NotificationDriver` class. Provides the following public functions, two for persistent notifications and one for one-shot notifications:

```java
public void updatePersistent(String content) // Persists existing title
public void updatePersistent(String title, String content)
public void sendOneShot(String title, String content)
```

Due to the need to share one `NotificationDriver` instance across every activity in the app, we use the Singleton class pattern. This means once the driver is initialized once in the `MainActivity`, it can only be access through e.g.

```java
var driver = NotificationDriver.getInstance(null);
driver.sendOneShot("Hello", "World!");
```

Notification permissions, starting with android 13, must be explicitly requested manually, so right now I'm prompting within `getInstance(null)`, so the first actual notification sent will prompt the user for permission. This seems to have the side effect of the first notification being lost, so maybe permission prompting should go elsewhere.